### PR TITLE
ActiveRecord::Base is no longer hard-coded

### DIFF
--- a/lib/bulk_insert.rb
+++ b/lib/bulk_insert.rb
@@ -40,7 +40,6 @@ module BulkInsert
       rows.map do |row|
         row = Hash[row.map{ |k, v| [k.to_s, v] }]
         values = @column_names.map { |n| row[n] }
-        connection.sanitize_sql_array([cached_value_sql, *values])
         connection_source.send(:sanitize_sql_array, [cached_value_sql, *values])
       end.join(', ')
     end


### PR DESCRIPTION
In order to make use of multiple databases, we need to be able to define the connection on a per query basis. This PR allows us to replace `ActiveRecord::Base` with any `ActiveRecord::Base` object.